### PR TITLE
Add support item EXP plugin

### DIFF
--- a/Plugin/SupportItemExp.js
+++ b/Plugin/SupportItemExp.js
@@ -1,0 +1,21 @@
+/*
+ * SupportItemExp.js
+ * Grants 25 experience when a wand (support item) is used on another unit.
+ * Place this file in your project's Plugin folder and enable it in the plugin manager.
+ */
+
+(function() {
+    var alias = BaseItemUse._getItemExperience;
+    BaseItemUse._getItemExperience = function(itemUseParent) {
+        var itemTargetInfo = itemUseParent.getItemTargetInfo();
+        var user = itemTargetInfo.unit;
+        var target = itemTargetInfo.targetUnit;
+        var item = itemTargetInfo.item;
+
+        if (item && item.isWand && item.isWand() && target !== null && user !== target) {
+            return ExperienceCalculator.getBestExperience(user, 25);
+        }
+
+        return alias.call(this, itemUseParent);
+    };
+})();


### PR DESCRIPTION
## Summary
- add `SupportItemExp.js` to grant 25 EXP when a wand is used on another unit

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b3368be308327af2def1f6f1e2a21