### PR TITLE
Fix enemy movement order and ally passability

### DIFF
--- a/Script/map/map-cource.js
+++ b/Script/map/map-cource.js
@@ -370,12 +370,13 @@ var CourceBuilder = {
 					movePoint = simulator.getSimulationMovePoint(index);
 					movePointMap = simulatorMap.getSimulationMovePoint(index);
 					// Check if the place where cannot move is now possible to move to.
-					if (movePoint === AIValue.MAX_MOVE && movePointMap !== AIValue.MAX_MOVE) {
-						if (PosChecker.getUnitFromPos(x2, y2) === null) {
-							blockUnitArray.push(targetUnit);
-							break;
-						}
-					}
+                                       if (movePoint === AIValue.MAX_MOVE && movePointMap !== AIValue.MAX_MOVE) {
+                                               var passUnit = PosChecker.getUnitFromPos(x2, y2);
+                                               if (passUnit === null || (passUnit.getUnitType() === unit.getUnitType() && passUnit.getOrderMark() === OrderMarkType.FREE)) {
+                                                       blockUnitArray.push(targetUnit);
+                                                       break;
+                                               }
+                                       }
 				}
 			}
 		}
@@ -421,11 +422,12 @@ var CourceBuilder = {
 			if (movePoint === 0) {
 				// Check if it can reach only one move.
 				if (type !== CourceType.VIRTUAL && firstPoint <= moveMaxCount) {
-					if (PosChecker.getUnitFromPos(xGoal, yGoal) !== null) {
-						// The unit exists at the goalIndex, so mark that cannot move there.
-						indexArrayDisabled.push(CurrentMap.getIndex(xGoal, yGoal));
-						return [];
-					}
+                                       var goalUnit = PosChecker.getUnitFromPos(xGoal, yGoal);
+                                       if (goalUnit !== null && !(goalUnit.getUnitType() === unit.getUnitType() && goalUnit.getOrderMark() === OrderMarkType.FREE)) {
+                                               // The unit exists at the goalIndex, so mark that cannot move there.
+                                               indexArrayDisabled.push(CurrentMap.getIndex(xGoal, yGoal));
+                                               return [];
+                                       }
 				}
 				
 				// Can reach at the unit current position, so exit the loop.
@@ -452,10 +454,11 @@ var CourceBuilder = {
 				if (movePoint > moveMaxCount && newPoint <= moveMaxCount) {
 					// If the unit exists at (x2, y2), overlap when move,
 					// so don't treat it as a course.
-					if (PosChecker.getUnitFromPos(x2, y2) !== null) {
-						indexArrayDisabled.push(CurrentMap.getIndex(x2, y2));
-						continue;
-					}
+                                       var blockUnit = PosChecker.getUnitFromPos(x2, y2);
+                                       if (blockUnit !== null && !(blockUnit.getUnitType() === unit.getUnitType() && blockUnit.getOrderMark() === OrderMarkType.FREE)) {
+                                               indexArrayDisabled.push(CurrentMap.getIndex(x2, y2));
+                                               continue;
+                                       }
 				}
 			}
 			
@@ -545,10 +548,11 @@ var CourceBuilder = {
 						return -1;
 					}
 					
-					if (PosChecker.getUnitFromPos(CurrentMap.getX(mapIndex), CurrentMap.getY(mapIndex)) === null) {
-						// The unit doesn't exist, so this position is goal.
-						return mapIndex;
-					}
+                                       var altUnit = PosChecker.getUnitFromPos(CurrentMap.getX(mapIndex), CurrentMap.getY(mapIndex));
+                                       if (altUnit === null || (altUnit.getUnitType() === unit.getUnitType() && altUnit.getOrderMark() === OrderMarkType.FREE)) {
+                                               // The unit doesn't exist, so this position is goal.
+                                               return mapIndex;
+                                       }
 				}
 			}
 		}

--- a/Script/map/map-enemyturn.js
+++ b/Script/map/map-enemyturn.js
@@ -390,9 +390,29 @@ var EnemyTurn = defineObject(BaseTurn,
 		return true;
 	},
 	
-	_getActorList: function() {
-		return TurnControl.getActorList();
-	},
+       _getActorList: function() {
+               var list = TurnControl.getActorList();
+               var count = list.getCount();
+               var arr = [];
+               var i;
+
+               for (i = 0; i < count; i++) {
+                       arr.push(list.getData(i));
+               }
+
+               arr.sort(function(a, b) {
+                       if (a.getMapX() === b.getMapX()) {
+                               return a.getMapY() - b.getMapY();
+                       }
+
+                       return b.getMapX() - a.getMapX();
+               });
+
+               var newList = StructureBuilder.buildDataList();
+               newList.setDataArray(arr);
+
+               return newList;
+       },
 	
 	_isSkipMode: function() {
 		return CurrentMap.isTurnSkipMode();

--- a/Script/map/map-enemyturnai.js
+++ b/Script/map/map-enemyturnai.js
@@ -240,8 +240,10 @@ var BaseCombinationCollector = defineObject(BaseObject,
 		else {
 			// There is a possibility that the player exists at the position (the player is processed to be passable).
 			// So check if the unit who is not myself exists.
-			posUnit = PosChecker.getUnitFromPos(x, y);
-			if (posUnit === null || posUnit === misc.unit) {
+                       posUnit = PosChecker.getUnitFromPos(x, y);
+                       if (posUnit === null || posUnit === misc.unit ||
+                               (posUnit.getUnitType() === misc.unit.getUnitType() &&
+                                posUnit.getOrderMark() === OrderMarkType.FREE)) {
 				// Create the cost because it can move to this position.
 				// The cost includes a target position to move and necessary steps to move.
 				this._createAndPushCost(misc);


### PR DESCRIPTION
## Summary
- sort enemies by map position so those ahead move first
- allow pathfinding to ignore allies that have not acted yet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b3b3326448327b1d074294c7e9ff0