### PR TITLE
Add state description in item tooltips

### DIFF
--- a/Plugin/StateTooltipInfo.js
+++ b/Plugin/StateTooltipInfo.js
@@ -1,6 +1,7 @@
 /*
  * StateTooltipInfo.js
- * Adds parameter bonus descriptions for states in item tooltips.
+ * Shows state descriptions in item tooltips.
+ * Falls back to parameter bonus text if the state has no description.
  * Place this file in your project's Plugin folder and enable it in the plugin manager.
  */
 
@@ -16,6 +17,13 @@
             }
         }
         return arr.join(', ');
+    };
+
+    var getStateDescriptionText = function(state) {
+        if (typeof state.getDescription === 'function') {
+            return state.getDescription();
+        }
+        return '';
     };
 
     ItemInfoRenderer.drawState = function(x, y, stateGroup, isRecovery) {
@@ -55,7 +63,10 @@
             }
             TextRenderer.drawKeywordText(x, y, state.getName(), -1, color, font);
             y += spaceY;
-            desc = getStateBonusText(state);
+            desc = getStateDescriptionText(state);
+            if (desc === '') {
+                desc = getStateBonusText(state);
+            }
             if (desc !== '') {
                 TextRenderer.drawText(x + spaceX, y - spaceY, desc, -1, color, font);
                 y += spaceY;


### PR DESCRIPTION
## Summary
- update `StateTooltipInfo.js` to show state descriptions in item tooltips
- fall back to stat bonus text if no description exists

## Testing
- `node -p "require('./Plugin/StateTooltipInfo.js'); console.log('OK');"` *(fails: ReferenceError because engine globals aren't defined)*

------
https://chatgpt.com/codex/tasks/task_e_6850b8bd81e88327bb8d096e2d12a611