### PR TITLE
Add item and state descriptions to tooltips

### DIFF
--- a/Plugin/StateTooltipInfo.js
+++ b/Plugin/StateTooltipInfo.js
@@ -1,6 +1,7 @@
 /*
  * StateTooltipInfo.js
- * Adds parameter bonus descriptions for states in item tooltips.
+ * Shows state descriptions in item tooltips.
+ * Falls back to parameter bonus text if the state has no description.
  * Place this file in your project's Plugin folder and enable it in the plugin manager.
  */
 
@@ -16,6 +17,50 @@
             }
         }
         return arr.join(', ');
+    };
+
+    var getStateDescriptionText = function(state) {
+        var text = '';
+
+        if (typeof state.getDescription === 'function') {
+            text = state.getDescription();
+        }
+
+        if (!text && state.custom) {
+            if (typeof state.custom.description === 'string') {
+                text = state.custom.description;
+            }
+            else if (typeof state.custom.desc === 'string') {
+                text = state.custom.desc;
+            }
+        }
+
+        return text || '';
+    };
+
+    var _aliasItemInfoRendererGetStateCount = ItemInfoRenderer.getStateCount;
+    ItemInfoRenderer.getStateCount = function(stateGroup) {
+        var count = _aliasItemInfoRendererGetStateCount.call(this, stateGroup);
+        var refList, i, state, desc;
+
+        if (!stateGroup.isAllBadState()) {
+            refList = stateGroup.getStateReferenceList();
+            for (i = 0; i < refList.getTypeCount(); i++) {
+                state = refList.getTypeData(i);
+                if (state.isHidden()) {
+                    continue;
+                }
+                desc = getStateDescriptionText(state);
+                if (desc === '') {
+                    desc = getStateBonusText(state);
+                }
+                if (desc !== '') {
+                    count++;
+                }
+            }
+        }
+
+        return count;
     };
 
     ItemInfoRenderer.drawState = function(x, y, stateGroup, isRecovery) {
@@ -55,11 +100,38 @@
             }
             TextRenderer.drawKeywordText(x, y, state.getName(), -1, color, font);
             y += spaceY;
-            desc = getStateBonusText(state);
+            desc = getStateDescriptionText(state);
+            if (desc === '') {
+                desc = getStateBonusText(state);
+            }
             if (desc !== '') {
                 TextRenderer.drawText(x + spaceX, y - spaceY, desc, -1, color, font);
                 y += spaceY;
             }
         }
+    };
+
+    var _aliasItemSentenceInfoDraw = ItemSentence.Info.drawItemSentence;
+    ItemSentence.Info.drawItemSentence = function(x, y, item) {
+        var text, textui, color, font;
+
+        text = typeof item.getDescription === 'function' ? item.getDescription() : '';
+        if (text) {
+            textui = ItemInfoRenderer.getTextUI();
+            color = textui.getColor();
+            font = textui.getFont();
+            TextRenderer.drawText(x, y, text, -1, color, font);
+            y += ItemInfoRenderer.getSpaceY();
+        }
+
+        _aliasItemSentenceInfoDraw.call(this, x, y, item);
+    };
+
+    var _aliasItemSentenceInfoCount = ItemSentence.Info.getItemSentenceCount;
+    ItemSentence.Info.getItemSentenceCount = function(item) {
+        var count = _aliasItemSentenceInfoCount.call(this, item);
+        var text = typeof item.getDescription === 'function' ? item.getDescription() : '';
+
+        return count + (text ? 1 : 0);
     };
 })();


### PR DESCRIPTION
## Summary
- expand `getStateDescriptionText` to read custom fields
- show item descriptions in tooltips via `ItemSentence.Info`
- still draw state descriptions or stat bonuses
- fix tooltip count for states with descriptions

## Testing
- `node -p "require('./Plugin/StateTooltipInfo.js'); console.log('OK');"` *(fails: ReferenceError because engine globals aren't defined)*

------
https://chatgpt.com/codex/tasks/task_e_6850b8bd81e88327bb8d096e2d12a611