### PR TITLE
Show item descriptions in tooltips

### DIFF
--- a/Plugin/StateTooltipInfo.js
+++ b/Plugin/StateTooltipInfo.js
@@ -109,27 +109,4 @@
         }
     };
 
-    var _aliasItemSentenceInfoDraw = ItemSentence.Info.drawItemSentence;
-    ItemSentence.Info.drawItemSentence = function(x, y, item) {
-        var text, textui, color, font;
-
-        text = typeof item.getDescription === 'function' ? item.getDescription() : '';
-        if (text) {
-            textui = ItemInfoRenderer.getTextUI();
-            color = textui.getColor();
-            font = textui.getFont();
-            TextRenderer.drawText(x, y, text, -1, color, font);
-            y += ItemInfoRenderer.getSpaceY();
-        }
-
-        _aliasItemSentenceInfoDraw.call(this, x, y, item);
-    };
-
-    var _aliasItemSentenceInfoCount = ItemSentence.Info.getItemSentenceCount;
-    ItemSentence.Info.getItemSentenceCount = function(item) {
-        var count = _aliasItemSentenceInfoCount.call(this, item);
-        var text = typeof item.getDescription === 'function' ? item.getDescription() : '';
-
-        return count + (text ? 1 : 0);
-    };
 })();

--- a/Script/window/window-iteminfo.js
+++ b/Script/window/window-iteminfo.js
@@ -85,28 +85,30 @@ var ItemInfoWindow = defineObject(BaseWindow,
 		return this._item;
 	},
 	
-	_configureWeapon: function(groupArray) {
-		groupArray.appendObject(ItemSentence.AttackAndHit);
-		groupArray.appendObject(ItemSentence.CriticalAndRange);
-		groupArray.appendObject(ItemSentence.WeaponLevelAndWeight);
-		groupArray.appendObject(ItemSentence.AdditionState);
-		groupArray.appendObject(ItemSentence.WeaponOption);
-		groupArray.appendObject(ItemSentence.Effective);
-		groupArray.appendObject(ItemSentence.ReverseWeapon);
-		groupArray.appendObject(ItemSentence.Skill);
-		groupArray.appendObject(ItemSentence.Only);
-		groupArray.appendObject(ItemSentence.Bonus);
-	},
+        _configureWeapon: function(groupArray) {
+                groupArray.appendObject(ItemSentence.Description);
+                groupArray.appendObject(ItemSentence.AttackAndHit);
+                groupArray.appendObject(ItemSentence.CriticalAndRange);
+                groupArray.appendObject(ItemSentence.WeaponLevelAndWeight);
+                groupArray.appendObject(ItemSentence.AdditionState);
+                groupArray.appendObject(ItemSentence.WeaponOption);
+                groupArray.appendObject(ItemSentence.Effective);
+                groupArray.appendObject(ItemSentence.ReverseWeapon);
+                groupArray.appendObject(ItemSentence.Skill);
+                groupArray.appendObject(ItemSentence.Only);
+                groupArray.appendObject(ItemSentence.Bonus);
+        },
 	
-	_configureItem: function(groupArray) {
-		groupArray.appendObject(ItemSentence.WeaponLevelAndWeight);
-		groupArray.appendObject(ItemSentence.Info);
-		groupArray.appendObject(ItemSentence.ResistState);
-		groupArray.appendObject(ItemSentence.Skill);
-		groupArray.appendObject(ItemSentence.Target);
-		groupArray.appendObject(ItemSentence.Only);
-		groupArray.appendObject(ItemSentence.Bonus);
-	}
+        _configureItem: function(groupArray) {
+                groupArray.appendObject(ItemSentence.Description);
+                groupArray.appendObject(ItemSentence.WeaponLevelAndWeight);
+                groupArray.appendObject(ItemSentence.Info);
+                groupArray.appendObject(ItemSentence.ResistState);
+                groupArray.appendObject(ItemSentence.Skill);
+                groupArray.appendObject(ItemSentence.Target);
+                groupArray.appendObject(ItemSentence.Only);
+                groupArray.appendObject(ItemSentence.Bonus);
+        }
 }
 );
 
@@ -136,6 +138,28 @@ var BaseItemSentence = defineObject(BaseObject,
 );
 
 var ItemSentence = {};
+
+ItemSentence.Description = defineObject(BaseItemSentence,
+{
+        drawItemSentence: function(x, y, item) {
+                var text = typeof item.getDescription === 'function' ? item.getDescription() : '';
+                var textui, color, font;
+
+                if (text) {
+                        textui = ItemInfoRenderer.getTextUI();
+                        color = textui.getColor();
+                        font = textui.getFont();
+                        TextRenderer.drawText(x, y, text, -1, color, font);
+                }
+        },
+
+        getItemSentenceCount: function(item) {
+                var text = typeof item.getDescription === 'function' ? item.getDescription() : '';
+
+                return text ? 1 : 0;
+        }
+}
+);
 
 ItemSentence.AttackAndHit = defineObject(BaseItemSentence,
 {


### PR DESCRIPTION
## Summary
- show item description text in ItemInfoWindow by default
- keep state description logic but remove plugin description override

## Testing
- `node -e "require('./Plugin/StateTooltipInfo.js');"` *(fails: ItemInfoRenderer is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6850fa911cbc8327811c0061b4dbaac2