### PR TITLE
Fix missing item descriptions in tooltip

### DIFF
--- a/Plugin/ItemDescTooltip.js
+++ b/Plugin/ItemDescTooltip.js
@@ -9,7 +9,51 @@
     var _aliasSetInfoItem = ItemInfoWindow.setInfoItem;
     ItemInfoRenderer._currentItemDesc = '';
     ItemInfoWindow.setInfoItem = function(item) {
-        ItemInfoRenderer._currentItemDesc = (item && typeof item.getDescription === 'function') ? item.getDescription() : '';
+        var desc = '';
+
+        if (item) {
+            if (typeof item.getDescription === 'function') {
+                desc = item.getDescription();
+            }
+
+            if (!desc && typeof item.description === 'string') {
+                desc = item.description;
+            }
+
+            if (!desc && typeof item.desc === 'string') {
+                desc = item.desc;
+            }
+
+            if (!desc && item.custom) {
+                if (typeof item.custom.description === 'string') {
+                    desc = item.custom.description;
+                }
+                else if (typeof item.custom.desc === 'string') {
+                    desc = item.custom.desc;
+                }
+
+                if (!desc) {
+                    var lower;
+                    for (var key in item.custom) {
+                        if (!item.custom.hasOwnProperty(key)) {
+                            continue;
+                        }
+                        if (typeof item.custom[key] === 'string') {
+                            lower = key.toLowerCase();
+                            if (lower.indexOf('desc') !== -1 ||
+                                lower.indexOf('description') !== -1 ||
+                                lower.indexOf('info') !== -1 ||
+                                lower.indexOf('text') !== -1) {
+                                desc = item.custom[key];
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        ItemInfoRenderer._currentItemDesc = desc;
         _aliasSetInfoItem.call(this, item);
     };
 


### PR DESCRIPTION
## Summary
- improve ItemDescTooltip description fallback logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685188a21a3c8327981333246b37bad1