### PR TITLE
Fix item swap duplication bug

### DIFF
--- a/Plugin/ItemSwaps.js
+++ b/Plugin/ItemSwaps.js
@@ -66,7 +66,8 @@ var autoEquipClassChange = function(unit) {
     } catch (e) {}
 
     if (usable) {
-      unit.setItem(slot++, item);
+      var newItem = root.duplicateItem(item);
+      unit.setItem(slot++, newItem);
       try { root.log("   ↳ Equipped: " + item.getName()); } catch (e) {}
     }
   }
@@ -89,7 +90,8 @@ var autoEquipClassChange = function(unit) {
     } catch (e) {}
 
     if (miscUsable) {
-      unit.setItem(slot++, misc);
+      var newMisc = root.duplicateItem(misc);
+      unit.setItem(slot++, newMisc);
       try { root.log("   ↳ Added: " + misc.getName()); } catch (e) {}
     }
   }


### PR DESCRIPTION
## Summary
- auto-equip now duplicates items instead of sharing instances

## Testing
- `node --check Plugin/ItemSwaps.js`

------
https://chatgpt.com/codex/tasks/task_e_68538fa1b8708327acbdce128475f1dc